### PR TITLE
added stream.destroy

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,6 +68,7 @@ app.get("/:ano/:numeroCarteiraDeputado/:despesa", (req, res) => {
       } else if (stopSign === false) {
         res.json(results);
         stopSign = true;
+        stream.destroy();
       }
     })
     .on("end", () => {


### PR DESCRIPTION
Calling stream.destroy() after the data is sent in the response will stop the stream from filling the buffer.